### PR TITLE
Updating deprecated shadow psuedo-selectors

### DIFF
--- a/lib/glowing-cursor.coffee
+++ b/lib/glowing-cursor.coffee
@@ -46,7 +46,7 @@ module.exports =
         transitionDuration = atom.config.get('glowing-cursor.transitionDuration')
         glowDistance = atom.config.get('glowing-cursor.glowDistance')
         pulseOnRule = createCSSOption(
-          "atom-text-editor::shadow .cursors .cursor"
+          "atom-text-editor .cursors .cursor"
           {
             transition: "opacity ease-in-out"
         	   "transition-duration": "#{transitionDuration}ms";
@@ -54,13 +54,13 @@ module.exports =
             "background-color": "#{innerColor}"
           })
         pulseOffRule = createCSSOption(
-          "atom-text-editor::shadow .cursors.blink-off .cursor"
+          "atom-text-editor .cursors.blink-off .cursor"
           {
             opacity: 0
             visibility: "visible !important"
           })
         cursorRule = createCSSOption(
-          "atom-text-editor::shadow .cursors .cursor"
+          "atom-text-editor .cursors .cursor"
           {
             width: "#{cursorWidth}px !important"
             "box-shadow": "0px 0px #{glowDistance}px 0px #{glowColor}"

--- a/styles/index.atom-text-editor.less
+++ b/styles/index.atom-text-editor.less
@@ -1,6 +1,6 @@
 /*this less file will hide the default cursor because we will be styling the shadow cursor in the coffeescript file*/
 
-atom-text-editor::shadow .cursors .cursor {
+atom-text-editor .cursors .cursor {
   opacity: 1;
   color: transparent;
   background-color: transparent;
@@ -8,6 +8,6 @@ atom-text-editor::shadow .cursors .cursor {
   transition-property: background-color, border-color, opacity;
 }
 
-atom-text-editor[mini]:not(.is-focused)::shadow .cursors .cursor {
+atom-text-editor[mini]:not(.is-focused) .cursors .cursor {
   display: none;
 }


### PR DESCRIPTION
See issue #5 

With one of the latest releases of atom the shadow and host psuedoselectors
were deprecated. https://github.com/atom/atom/pull/12903. Removing
those deprecated psuedoselectors as they are no longer needed.

